### PR TITLE
fpsadjust.lua: Also set fps value

### DIFF
--- a/home/nand/.mpv/scripts/fpsadjust.lua
+++ b/home/nand/.mpv/scripts/fpsadjust.lua
@@ -37,6 +37,9 @@ function adjust_speed(event)
     if scale then
         mp.set_property("speed", scale)
         print("Setting speed to", scale)
+        fps=clip_fps*scale
+        mp.set_property("fps", fps)
+        print("Setting fps to", fps)
     end
 end
 


### PR DESCRIPTION
If speed-property is overwritten, also overwrite fps-property. 
Like this, container_fps will get this fps, and vapoursynth-mvtools-filter (if used) sees the container-fps after "speed" has scaled it, otherwise mvtools and fpsadjust should not be used together.

For me, this improves the experience when using both together (also over using mvtools alone, since mvtools has less to interpolate in this case, if all goes well, all original frames can be kept). 

Example situation: 
23.9765 fps => speedup to 24 fps => mvtools interpolates from 24 fps to 60 fps (and then, for my screen, smoothmotion-interpolation can interpolate to 120 Hz). 

Without this applied: 
23.9765 => speedup to 24 fps => mvtools assumed 23.9765 fps, but gets 24 fps and interpolates to 60 fps => judder. 
